### PR TITLE
Updating IP binding from local loop to accepting all traffic

### DIFF
--- a/rust-web-server/src/main.rs
+++ b/rust-web-server/src/main.rs
@@ -7,7 +7,7 @@ fn config(cfg: &mut web::ServiceConfig) {
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     HttpServer::new(|| App::new().configure(config))
-        .bind("127.0.0.1:8080")?
+        .bind("0.0.0.0:8080")?
         .run()
         .await
 }


### PR DESCRIPTION
I was using this example to setup a local server and found that this example uses a localhost loop IP. This creates an issue when I try to access this server from remote. Updating it to `0.0.0.0` will make it accept remote traffic as well which is probably what most people want.